### PR TITLE
convert inputs to NanoEvents when Spark is used

### DIFF
--- a/config/parameters.py
+++ b/config/parameters.py
@@ -373,23 +373,30 @@ parameters["dnn_max"] = {
 }
 
 event_branches = ['run', 'luminosityBlock', 'genWeight', 'event']
-muon_branches = ['nMuon', 'Muon_pt', 'Muon_eta', 'Muon_phi', 'Muon_mass', 'Muon_charge', 'Muon_pfRelIso04_all']
-jet_branches = ['nJet', 'Jet_pt', 'Jet_eta', 'Jet_phi', 'Jet_mass', 'Jet_qgl', 'Jet_jetId', 'Jet_puId']
+muon_branches = ['nMuon', 'Muon_pt', 'Muon_ptErr', 'Muon_eta', 'Muon_phi', 'Muon_mass', 'Muon_charge', 'Muon_pfRelIso04_all', 'Muon_mediumId','Muon_fsrPhotonIdx', 'Muon_jetIdx']
+fsr_branches = ['nFsrPhoton', 'FsrPhoton_pt', 'FsrPhoton_eta', 'FsrPhoton_phi', 'FsrPhoton_relIso03', 'FsrPhoton_dROverEt2']
+trig_branches = ['nTrigObj', 'TrigObj_pt', 'TrigObj_eta', 'TrigObj_phi', 'TrigObj_mass', 'TrigObj_id']
+jet_branches = ['nJet', 'Jet_pt', 'Jet_eta', 'Jet_phi', 'Jet_mass', 'Jet_qgl', 'Jet_jetId', 'Jet_puId', 'Jet_electronIdx1', 'Jet_electronIdx2', 'Jet_muonIdx1', 'Jet_muonIdx2', 'Jet_rawFactor', 'fixedGridRhoFastjetAll', 'Jet_btagDeepB', 'Jet_area']
+genjet_branches = ['nGenJet', 'GenJet_pt', 'GenJet_eta', 'GenJet_phi']
+sajet_branches = ['nSoftActivityJet', 'SoftActivityJet_pt', 'SoftActivityJet_eta', 'SoftActivityJet_phi', 'SoftActivityJetNjets2', 'SoftActivityJetHT2', 'SoftActivityJetNjets5', 'SoftActivityJetHT5']
 vtx_branches = ['Pileup_nTrueInt', 'PV_npvsGood'] 
 other_branches = ['MET_pt']
+electron_branches = ['nElectron', 'Electron_pt', 'Electron_eta', 'Electron_mvaFall17V2Iso_WP90']
 event_flags = ['Flag_BadPFMuonFilter','Flag_EcalDeadCellTriggerPrimitiveFilter',
                 'Flag_HBHENoiseFilter','Flag_HBHENoiseIsoFilter',
                 'Flag_globalSuperTightHalo2016Filter','Flag_goodVertices',
                #'Flag_BadChargedCandidateFilter'
               ]
 
+puid17 = ['Jet_puId17']
+
 branches_2016 = ['HLT_IsoMu24', 'HLT_IsoTkMu24', 'L1PreFiringWeight_Nom', 'L1PreFiringWeight_Up', 'L1PreFiringWeight_Dn']
 branches_2017 = ['HLT_IsoMu27', 'L1PreFiringWeight_Nom', 'L1PreFiringWeight_Up', 'L1PreFiringWeight_Dn']
 branches_2018 = ['HLT_IsoMu24']
 
-proc_columns = event_branches + muon_branches + jet_branches + vtx_branches + other_branches #+ event_flags 
+proc_columns = event_branches + muon_branches + jet_branches + vtx_branches + other_branches + fsr_branches + genjet_branches + electron_branches + trig_branches + sajet_branches
 parameters["proc_columns"] = {
     "2016": proc_columns + branches_2016,
-    "2017": proc_columns + branches_2017,
+    "2017": proc_columns + branches_2017 + puid17,
     "2018": proc_columns + branches_2018,
 }


### PR DESCRIPTION
These changes implement conversion to NanoEvents format using `from_arrays` method as described here: https://github.com/CoffeaTeam/coffea/blob/8ca2b3033fad516aaaf19f50fe693d2ba3f640a4/coffea/nanoaod/nanoevents.py#L44

In order to enable it, you need to add one more argument to `DimuonProcessor` like this:
```
DimuonProcessor(samp_info=samp_info, do_jecunc=False, use_spark=True)
```

I debugged it until the point where the error that Spark is throwing doesn't refer to a specific place in the code anymore. 

Below is the error that I'm getting with this setup – I'm not sure if he problem is on my side or on Spark side.
```
Traceback (most recent call last):
  File "try_spark.py", line 112, in <module>
    executor_args={'file_type': 'edu.vanderbilt.accre.laurelin.Root', 'cache': False, 'nano': True, 'retries': 5})
  File "/home/dkondra/.local/lib/python3.7/site-packages/coffea/processor/executor.py", line 989, in run_spark_job
    executor(spark, dfslist, processor_instance, output, thread_workers, use_cache, flatten)
  File "/home/dkondra/.local/lib/python3.7/site-packages/coffea/processor/spark/spark_executor.py", line 111, in __call__
    _futures_handler(futures, self._rawresults, status, unit, desc, spex_accumulator, None)
  File "/home/dkondra/.local/lib/python3.7/site-packages/coffea/processor/executor.py", line 192, in _futures_handler
    add_fn(output, finished.pop().result())
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/concurrent/futures/_base.py", line 428, in result
    return self.__get_result()
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/dkondra/.local/lib/python3.7/site-packages/coffea/processor/spark/spark_executor.py", line 132, in _launch_analysis
    .groupBy().agg(agg_histos('histos')) \
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/site-packages/pyspark/sql/dataframe.py", line 2129, in toPandas
    batches = self._collectAsArrow()
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/site-packages/pyspark/sql/dataframe.py", line 2191, in _collectAsArrow
    jsocket_auth_server.getResult()  # Join serving thread and raise any exceptions
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/site-packages/py4j/java_gateway.py", line 1257, in __call__
    answer, self.gateway_client, self.target_id, self.name)
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/site-packages/pyspark/sql/utils.py", line 63, in deco
    return f(*a, **kw)
  File "/home/dkondra/.conda/envs/cent7/5.3.1-py37/hmumu_coffea/lib/python3.7/site-packages/py4j/protocol.py", line 328, in get_return_value
    format(target_id, ".", name), value)
py4j.protocol.Py4JJavaError: An error occurred while calling o467.getResult.
```